### PR TITLE
use redis.set instead of setnx and expire

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-reservation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Resource reservation (locking) libraries using a Redis backend, with customizable timeouts and keep-alive support.",
   "main": "index.js",
   "scripts": {

--- a/test/reservation.coffee
+++ b/test/reservation.coffee
@@ -11,8 +11,7 @@ class BaseWorker
     worker_domain = domain.create()
     worker_domain.on 'error', (err) =>
       console.log "FAILED: Exception caught by domain:", err.stack
-      setTimeout @_die, 1000, err if @_exit_on_throw
-      worker_domain.exit()
+      worker_domain.dispose()
     worker_domain.once 'error', (err) => @_complete err  # only call complete once
     @reservation = new ReserveResource @constructor._name,
       process.env.REDIS_HOST or null,
@@ -22,6 +21,7 @@ class BaseWorker
     setImmediate =>
       worker_domain.enter()
       @_run payload, (args...) =>
+        worker_domain.exit()
         @_complete args...
   _complete: (args...) ->
     @reservation.release (err) =>


### PR DESCRIPTION
this is the current preferred method and also makes taking a lock completely atomic. 

http://redis.io/commands/set
